### PR TITLE
Move min_code validation to UserCreatedMinistry

### DIFF
--- a/app/models/ministry.rb
+++ b/app/models/ministry.rb
@@ -32,7 +32,7 @@ class Ministry < ActiveRecord::Base
   validates :name, presence: true
   validates :default_mcc, inclusion: { in: MCCS, message: '\'%{value}\' is not a valid MCC' },
                           unless: 'default_mcc.blank?'
-  validates :min_code, presence: true, uniqueness: true, on: :create
+  validates :min_code, uniqueness: true, on: :create, if: 'min_code.present?'
   before_validation :generate_min_code, on: :create, if: 'gr_id.blank?'
 
   authorize_values_for :parent_id, message: 'Only leaders of both ministries may move a ministry'

--- a/app/models/ministry/user_created_ministry.rb
+++ b/app/models/ministry/user_created_ministry.rb
@@ -5,6 +5,8 @@ class Ministry
 
     authorize_values_for :parent_id
 
+    validates :min_code, presence: true, on: :create
+
     after_create :create_admin_assignment
 
     private


### PR DESCRIPTION
While working on the import for ministries, I noticed that sometimes the `min_code` is set to `nil` even though the `gr_id` has a value. @Omicron7 mentioned that is OK and suggested doing this move of the validation for the presence of `min_code` to `UserCreatedMinistry`.

I thought it would be good to keep the `unique` validation in `Ministry` though.