### PR TITLE
Data import script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ vendor/ruby
 
 # Environment
 .env.*
+
+# Carrier wave test files
+public/uploads

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,2 +1,5 @@
 class ImageUploader < CarrierWave::Uploader::Base
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,4 +46,7 @@ Rails.application.configure do
   HttpLogger.ignore = [/newrelic\.com/]
   HttpLogger.log_request_body  = false
   HttpLogger.log_response_body = false
+
+  # Allow us to turn off HTTP logging with an env var
+  HttpLogger.logger.level = Logger::Severity::UNKNOWN if ENV['NO_HTTP_LOGGER']
 end

--- a/import_from_csv.sh
+++ b/import_from_csv.sh
@@ -1,0 +1,2 @@
+echo Importing from CSV writing results to tmp/import_results.txt
+NO_HTTP_LOGGER=1 bundle exec rake measurements_api:import_csv_data[tmp/sql_server_csv_dump] > tmp/import_results.txt

--- a/lib/import.rb
+++ b/lib/import.rb
@@ -1,0 +1,97 @@
+require 'csv'
+require 'tree_order'
+require 'import_mappings'
+
+# For importing from the old SQL Server database that has been dumped to CSV
+class Import
+  def initialize(csv_dump_folder)
+    @folder = csv_dump_folder
+    @empty_objects ||= {}
+  end
+
+  def import
+    Rails.logger.info("Importing from #{@folder}:")
+    ImportMappings::MAPPINGS.each do |mapping|
+      import_model(*mapping)
+    end
+  end
+
+  private
+
+  attr_reader :folder
+
+  def import_model(klass, csv_table, field_mapping, object_tap_proc = nil, rows_map_proc = nil)
+    start_count = klass.count
+    Rails.logger.info("\nImporting #{klass.name} from #{csv_table}.csv ...")
+    csv_rows(csv_table, rows_map_proc).each do |row|
+      import_object(klass, row, field_mapping, object_tap_proc)
+    end
+    num_imported = klass.count - start_count
+    Rails.logger.info("Imported #{num_imported} #{klass.table_name}.")
+  end
+
+  def import_object(klass, row, field_mapping, object_tap_proc)
+    object = new_with_field_mapping(klass, row, field_mapping)
+    object_tap_proc.call(object, row) if object_tap_proc.present?
+    object.save!
+  rescue SkipRecord
+    # We are intentionally skipping this record so do nothing
+    nil
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique,
+         ActiveRecord::RecordNotFound, ActiveRecord::StatementInvalid => e
+    Rails.logger.info("Error importing row #{row}: #{e}")
+  end
+
+  def new_with_field_mapping(klass, row, field_mapping)
+    args = matching_key_args(klass, row).merge(mapped_values(row, field_mapping))
+    klass.new(args)
+  end
+
+  def mapped_values(row, field_mapping)
+    Hash[field_mapping.map { |from, to| [to, row[from]] }]
+  end
+
+  def matching_key_args(klass, row)
+    associations = klass.reflect_on_all_associations.map(&:name)
+    matching_args = {}
+    object = empty_object(klass)
+    row.headers.each do |field|
+      next unless object.respond_to?("#{field}=")
+      next if field.in?(associations)
+      matching_args[field] = field_value(klass, field, row)
+    end
+    matching_args
+  end
+
+  def field_value(klass, field, row)
+    val = row[field]
+    if enum_field?(klass, field)
+      klass.send(pluralized_field(field)).invert[val]
+    else
+      val
+    end
+  end
+
+  def enum_field?(klass, field)
+    pluralized = pluralized_field(field)
+    klass.respond_to?(pluralized) && klass.send(pluralized).is_a?(Hash)
+  end
+
+  def pluralized_field(field)
+    field.to_s.pluralize.to_sym
+  end
+
+  def empty_object(klass)
+    @empty_objects[klass] ||= klass.new
+  end
+
+  def csv_rows(table, rows_map_proc = nil)
+    rows = CSV.foreach("#{folder}/#{table}.csv", headers: true,
+                                                 header_converters: :symbol)
+    return rows if rows_map_proc.blank?
+    rows_map_proc.call(rows)
+  end
+
+  class SkipRecord < StandardError
+  end
+end

--- a/lib/import_mappings.rb
+++ b/lib/import_mappings.rb
@@ -123,6 +123,17 @@ class ImportMappings
       end
     ],
     [
+      Story, :story, {},
+      lambda do |story, row|
+        story.created_by_id = ImportUtil.person_id_by_gr_id(row[:created_by])
+        story.ministry_id = ImportUtil.ministry_id_by_gr_id(row[:ministry_id])
+        if row[:image_url] =~ /singlebestrecord\.blob\.core\.windows\.net/
+          story.image_url = nil
+          ImportUtil.import_story_image(story, row[:image_url])
+        end
+      end
+    ],
+    [
       Assignment, :assignment, { assignment_id: :gr_id },
       lambda do |assignment, row|
         role = row[:team_role]

--- a/lib/import_mappings.rb
+++ b/lib/import_mappings.rb
@@ -1,0 +1,139 @@
+require 'import_util'
+
+class ImportMappings
+  # Array of mappings for how to import from CSV dumps of the old measurements
+  # api data.
+  MAPPINGS = [
+    # Template:
+    # [
+    #  Model, :csv_dump_file, { old_csv_field: new_model_field },
+    #  labmda do |model_object, row|
+    #    model_object.some_field = custom_method(row[:field])
+    #  end,
+    #  lambda do |rows|
+    #    rows.sort
+    #  end
+    # ]
+    [
+      Ministry, :ministries,
+      {
+        min_id: :gr_id,
+        min_scope: :ministry_scope,
+        parent_min_id: :parent_gr_id,
+        lat: :latitude,
+        long: :longitude,
+        zoom: :location_zoom,
+        currency_sybmol: :currency_symbol
+      },
+      lambda do |ministry, row|
+        ministry.min_code = nil if ministry.min_code.blank?
+        ministry.mccs << Ministry::MCC_SLM if row[:slm]
+        ministry.mccs << Ministry::MCC_LLM if row[:llm]
+        ministry.mccs << Ministry::MCC_GCM if row[:gcm]
+        ministry.mccs << Ministry::MCC_DS if row[:ds]
+      end,
+      lambda do |rows|
+        TreeOrder.new(rows, :id, :parent_id).ordered_parents_first
+      end
+    ],
+    [Person, :person, { person_id: :gr_id }],
+    [
+      Audit, :audit, { timestamp: :created_at },
+      lambda do |audit, row|
+        if row[:type].present?
+          audit.audit_type = Audit.audit_types.invert[row[:type].to_i]
+        end
+        audit.person_id = ImportUtil.person_id_by_gr_id(row[:person_id])
+        audit.ministry_id = ImportUtil.ministry_id_by_gr_id(row[:ministry_id])
+      end
+    ],
+    [
+      Church, :gcm_churches, { last_updated: :updated_at },
+      lambda do |church, row|
+        church.created_by_id = ImportUtil.person_id_by_gr_id(row[:created_by]) if row[:created_by].present?
+        church.ministry_id =
+          if row[:target_area_id].present?
+            ImportUtil.ministry_id_by_gr_id(row[:target_area_id])
+          elsif row[:target_area].present?
+            ImportUtil.find_ministry_id(row[:target_area])
+          end
+      end,
+      lambda do |rows|
+        TreeOrder.new(rows, :id, :parent_id).ordered_parents_first
+      end
+    ],
+    [
+      ChurchValue, :church_value, {},
+      lambda do |_church_value, row|
+        church = Church.find_by(id: row[:church_id])
+        unless church
+          Rails.logger.info "Can't find church for id #{row[:church_id]}"
+          raise Import::SkipRecord
+        end
+      end
+    ],
+    [Measurement, :measurements, {}],
+    [
+      MeasurementTranslation, :measurements_trans, {},
+      lambda do |measurement_trans, row|
+        measurement_trans.ministry_id = ImportUtil.ministry_id_by_gr_id(row[:ministry_id])
+      end
+    ],
+    [
+      Training, :gcm_training, {},
+      lambda do |training, row|
+        training.created_by_id = ImportUtil.person_id_by_gr_id(row[:created_by]) if row[:created_by].present?
+        training.ministry_id = ImportUtil.ministry_id_by_gr_id(row[:ministry_id])
+      end
+    ],
+    [
+      TrainingCompletion, :gcm_training_completion,
+      { last_updated: :updated_at }
+    ],
+    [
+      UserMeasurementState, :default_measurement_states, {},
+      lambda do |state, row|
+        state.person_id = ImportUtil.person_id_by_gr_id(row[:person_id])
+        raise Import::SkipRecord unless state.person_id.present?
+      end
+    ],
+    [
+      UserMapView, :default_map_views, {},
+      lambda do |view, row|
+        view.person_id = ImportUtil.person_id_by_gr_id(row[:person_id])
+        raise Import::SkipRecord unless view.person_id.present?
+        view.ministry_id = ImportUtil.ministry_id_by_gr_id(row[:min_id])
+        raise Import::SkipRecord unless view.ministry_id.present?
+      end
+    ],
+    [
+      UserContentLocale, :user_pref_content_locale, {},
+      lambda do |user_locale, row|
+        user_locale.person_id = ImportUtil.person_id_by_gr_id(row[:person_id])
+        raise Import::SkipRecord unless user_locale.person_id.present?
+        user_locale.ministry_id = ImportUtil.ministry_id_by_gr_id(row[:ministry_id])
+        raise Import::SkipRecord unless user_locale.ministry_id.present?
+      end
+    ],
+    [
+      UserPreference, :user_preferences, {},
+      lambda do |user_pref, row|
+        user_pref.person_id = ImportUtil.person_id_by_gr_id(row[:person_id])
+        raise Import::SkipRecord unless user_pref.person_id.present?
+      end
+    ],
+    [
+      Assignment, :assignment, { assignment_id: :gr_id },
+      lambda do |assignment, row|
+        role = row[:team_role]
+        raise Import::SkipRecord if role.blank? || role.start_with?('inherited')
+        assignment.person_id = ImportUtil.person_id_by_gr_id(row[:person_id])
+        raise Import::SkipRecord if assignment.person_id.blank?
+        assignment.ministry_id = ImportUtil.ministry_id_by_gr_id(row[:ministry_id])
+        raise Import::SkipRecord if assignment.ministry.blank?
+        assignment.role = Assignment.roles[role]
+        raise "Unexpected role: #{row[:team_role]}" unless assignment.role
+      end
+    ]
+  ].freeze
+end

--- a/lib/import_util.rb
+++ b/lib/import_util.rb
@@ -1,0 +1,49 @@
+class ImportUtil
+  class << self
+    def find_ministry_id(id)
+      ministry = Ministry.find_by(id: id)
+      return ministry.id if ministry
+      missing_ministry_by_id(id)
+      nil
+    end
+
+    def ministry_id_by_gr_id(gr_id)
+      ministry = Ministry.ministry(gr_id)
+      return ministry.id if ministry
+      missing_ministry_by_gr_id(gr_id)
+      nil
+    end
+
+    def person_id_by_gr_id(gr_id)
+      person = Person.find_by(gr_id: gr_id)
+      return person.id if person
+      entity = Person.find_entity(gr_id, entity_type: 'person')
+      unless entity
+        @missing_person_gr_ids ||= {}
+        Rails.logger.info("No person entity found for gr_id: #{gr_id}") unless @missing_person_gr_ids[gr_id]
+        @missing_person_gr_ids[gr_id] = true
+        return nil
+      end
+      person = Person.new
+      person.from_entity(entity)
+      person.save
+      person.id
+    end
+
+    private
+
+    def missing_ministry_by_id(id)
+      @missing_ministry_ids ||= {}
+      return if @missing_ministry_ids[id]
+      Rails.logger.info("No ministry found for id: #{id}")
+      @missing_ministry_ids[id] = true
+    end
+
+    def missing_ministry_by_gr_id(gr_id)
+      @missing_ministry_gr_ids ||= {}
+      return if @missing_ministry_gr_ids[gr_id]
+      Rails.logger.info("No ministry found for gr_id: #{gr_id}")
+      @missing_ministry_gr_ids[gr_id] = true
+    end
+  end
+end

--- a/lib/tasks/measurements_api.rake
+++ b/lib/tasks/measurements_api.rake
@@ -1,0 +1,10 @@
+namespace :measurements_api do
+  # Call this as follows:
+  # bundle exec rake measurements_api:import_data[exported_csv_folder]
+  task :import_csv_data, [:csv_folder] => :environment do |_task, args|
+    require_relative '../import'
+    Rails.logger = Logger.new(STDOUT)
+    Rails.logger.formatter = ActiveSupport::Logger::SimpleFormatter.new
+    Import.new(args[:csv_folder]).import
+  end
+end

--- a/lib/tree_order.rb
+++ b/lib/tree_order.rb
@@ -1,0 +1,41 @@
+class TreeOrder
+  def initialize(rows, id_field, parent_id_field)
+    @rows = rows
+    @id_field = id_field
+    @parent_id_field = parent_id_field
+    @ordered_rows = []
+    @ordered_rows_set = Set.new
+    @children = {}
+  end
+
+  def ordered_parents_first
+    collect_children
+    order_parents_first(nil)
+    @ordered_rows
+  end
+
+  private
+
+  def order_parents_first(parent_id)
+    children = @children[parent_id]
+    return unless children.present?
+    children.each do |child|
+      add_child(child)
+      order_parents_first(child[@id_field])
+    end
+  end
+
+  def add_child(child)
+    !child.in?(@ordered_rows_set) || raise("Cycle found for #{child.inspect}")
+    @ordered_rows_set << child
+    @ordered_rows << child
+  end
+
+  def collect_children
+    @rows.each do |row|
+      parent_id = row[@parent_id_field]
+      @children[parent_id] ||= []
+      @children[parent_id] << row
+    end
+  end
+end


### PR DESCRIPTION
Here's the data import script. Here's what you need to do to get the data properly imported:
- Create the directory `tmp/sql_server_csv_dump` under your `measurements_api` folder e.g. from the folder run `mkdir -p tmp/sql_server_csv_dump]`
- Go to Navicat for SQL Server and select all the tables and click Export. Choose CSV File, for the path, select the `sql_server_csv_dump` folder you just created. Choose to export all fields, then in the additional options choose "Include column titles" and for the "Text Qualifier" select `"`.
- Once the import finishes, go back to the measurements api folder and run `import_from_csv.sh`.
- The output of the import will be saved to a file `tmp/import_results.txt`.
- The import is designed to run against the production global registry since the keys in the SQL server database point to the prod global registry. I have a key from Josh for the prod global registry that is effectively a read-only key (it is for a temporary organization that has read-only access to the production measurements api data).