### PR TITLE
Force SSL on requests except lb for monitor

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::API
+  force_ssl(if: :ssl_configured?, except: :lb)
+
+  def ssl_configured?
+    !Rails.env.development? && !Rails.env.test?
+  end
 end


### PR DESCRIPTION
This will enforce that clients use HTTPS when accessing the API.