### PR TITLE
Update our data when ministry or person changes in GR

### DIFF
--- a/app/models/concerns/gr_sync/entity_methods.rb
+++ b/app/models/concerns/gr_sync/entity_methods.rb
@@ -60,8 +60,10 @@ module GrSync
         %i(id client_integration_id)
       end
 
-      def create_from_entity(_params = {})
-        # TODO: implement
+      def create_or_update_from_entity!(entity)
+        record = find_or_initialize_by(gr_id: entity.values.first['id'])
+        record.from_entity(entity)
+        record.save!
       end
 
       def find_entity(id, params = {})

--- a/app/models/gr_sync/change_notification_handler.rb
+++ b/app/models/gr_sync/change_notification_handler.rb
@@ -1,0 +1,27 @@
+module GrSync
+  class ChangeNotificationHandler
+    def initialize(entity_type_name, entity_id)
+      @model = SubscribedEntities.model_for_name(entity_type_name)
+      @gr_id = entity_id
+    end
+
+    def created_notification
+      created_or_updated_notification
+    end
+
+    def updated_notification
+      created_or_updated_notification
+    end
+
+    def deleted_notification
+      @model.find_by(gr_id: @gr_id).try(&:destroy!)
+    end
+
+    private
+
+    def created_or_updated_notification
+      entity = GlobalRegistryClient.client.find(@gr_id)
+      @model.create_or_update_from_entity!(entity)
+    end
+  end
+end

--- a/app/models/gr_sync/merge_notification_handler.rb
+++ b/app/models/gr_sync/merge_notification_handler.rb
@@ -1,0 +1,19 @@
+module GrSync
+  class MergeNotificationHandler
+    def initialize(winner_entity_id, loser_entity_id)
+      @winner_gr_id = winner_entity_id
+      @loser_gr_id = loser_entity_id
+    end
+
+    def merge_success_notification
+      # We should update the winner and destory the loser but we would need to
+      # also merge all the child records too.
+      raise 'Merge success notification not implemented yet.'
+    end
+
+    def merge_conflict_notification
+      # Not sure what to do here yet
+      raise 'Merge conflict notification not implemented yet.'
+    end
+  end
+end

--- a/app/models/gr_sync/subscribed_entities.rb
+++ b/app/models/gr_sync/subscribed_entities.rb
@@ -1,0 +1,26 @@
+module GrSync
+  class SubscribedEntities
+    class << self
+      # We don't subscribe to changes from Assignment to prevent another system
+      # from adding an Assignment entity and thus gaining access to data in the
+      # measurements api.
+      ENTITY_MODELS = [::Ministry, ::Person].freeze
+
+      NAMES_TO_MODELS = Hash[ENTITY_MODELS.map { |m| [m.entity_type, m] }].freeze
+      ENTITY_NAMES = NAMES_TO_MODELS.values.freeze
+
+      def entity_type_ids
+        EntityTypeFinder.entity_type_ids(ENTITY_NAMES)
+      end
+
+      def model_for_entity(entity)
+        model_for_name(entity.keys.first)
+      end
+
+      def model_for_name(name)
+        # Give an exception if you try to find a model with no name
+        NAMES_TO_MODELS.fetch(name)
+      end
+    end
+  end
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -8,7 +8,7 @@ class Person < ActiveRecord::Base
 
   has_many :assignments, dependent: :destroy, inverse_of: :person
   has_many :ministries, through: :assignments
-  has_many :stories, dependent: :destroy
+  has_many :stories, foreign_key: :created_by_id, dependent: :destroy
 
   # Map GR key_username to cas_username
   alias_attribute :key_username, :cas_username

--- a/app/workers/gr_sync/notification_worker.rb
+++ b/app/workers/gr_sync/notification_worker.rb
@@ -2,7 +2,31 @@ module GrSync
   class NotificationWorker
     include Sidekiq::Worker
 
-    def perform(_notification)
+    def perform(notification)
+      if notification['action'] == 'merge'
+        merge_notification(notification)
+      else
+        change_notification(notification)
+      end
+    end
+
+    private
+
+    def merge_notification(notification)
+      winner_id = notification['new_id'] || notification['winner']['id']
+      loser_id = notification['old_id'] || notification['loser']['id']
+      handler = MergeNotificationHandler.new(winner_id, loser_id)
+      if notification['new_id'].present?
+        handler.merge_success_notification
+      else
+        handler.merge_conflict_notification
+      end
+    end
+
+    def change_notification(notification)
+      ChangeNotificationHandler
+        .new(notification['entity_type'], notification['id'])
+        .public_send("#{notification['action']}_notification")
     end
   end
 end

--- a/app/workers/gr_sync/setup_subscriptions_worker.rb
+++ b/app/workers/gr_sync/setup_subscriptions_worker.rb
@@ -2,18 +2,11 @@ module GrSync
   class SetupSubscriptionsWorker
     include Sidekiq::Worker
 
-    ENTITY_MODELS = [::Ministry, ::Person].freeze
-    ENTITY_NAMES = ENTITY_MODELS.map(&:entity_type)
-
     def perform
-      SubscriptionManager.new(entity_type_ids, endpoint).ensure_subscribed_to_all
+      SubscriptionManager.new(SubscribedEntities.entity_type_ids, endpoint).ensure_subscribed_to_all
     end
 
     private
-
-    def entity_type_ids
-      EntityTypeFinder.entity_type_ids(ENTITY_NAMES)
-    end
 
     def endpoint
       Rails.application.routes.url_helpers.gr_sync_notifications_url

--- a/spec/models/gr_sync/change_notification_handler_spec.rb
+++ b/spec/models/gr_sync/change_notification_handler_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe GrSync::ChangeNotificationHandler do
+  it 'creates or updates from entity for create notification' do
+    expect_created_or_updated_from_entity(:created_notification)
+  end
+
+  it 'creates or updates from entity for update notification' do
+    expect_created_or_updated_from_entity(:updated_notification)
+  end
+
+  def expect_created_or_updated_from_entity(notification_method)
+    entity = {
+      'person' => { 'id' => '1f', 'name' => 'Joe' }
+    }
+    client = double(find: entity)
+    allow(GlobalRegistryClient).to receive(:client) { client }
+    allow(Person).to receive(:create_or_update_from_entity!)
+
+    GrSync::ChangeNotificationHandler.new('person', '1f')
+                                     .public_send(notification_method)
+
+    expect(client).to have_received(:find).with('1f')
+    expect(Person).to have_received(:create_or_update_from_entity!).with(entity)
+  end
+
+  it 'deletes a record if deleted in global registry' do
+    person = create(:person)
+
+    expect do
+      GrSync::ChangeNotificationHandler.new('person', person.gr_id)
+                                       .deleted_notification
+    end.to change(Person, :count).by(-1)
+  end
+
+  it 'does not error for delete notification for non-existent record' do
+    expect do
+      GrSync::ChangeNotificationHandler.new('person', '1').deleted_notification
+    end.to_not raise_error
+  end
+end

--- a/spec/models/gr_sync/merge_notification_handler_spec.rb
+++ b/spec/models/gr_sync/merge_notification_handler_spec.rb
@@ -1,4 +1,19 @@
 require 'rails_helper'
 
 describe GrSync::MergeNotificationHandler do
+  context '#merge_success_notification' do
+    it "raises an exception because it's not implemented yet" do
+      expect do
+        GrSync::MergeNotificationHandler.new('1', '2').merge_success_notification
+      end.to raise_error(/not implemented/)
+    end
+  end
+
+  context '#merge_conflict_notification' do
+    it "raises an exception because it's not implemented yet" do
+      expect do
+        GrSync::MergeNotificationHandler.new('1', '2').merge_conflict_notification
+      end.to raise_error(/not implemented/)
+    end
+  end
 end

--- a/spec/models/gr_sync/merge_notification_handler_spec.rb
+++ b/spec/models/gr_sync/merge_notification_handler_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+describe GrSync::MergeNotificationHandler do
+end

--- a/spec/models/ministry_spec.rb
+++ b/spec/models/ministry_spec.rb
@@ -159,4 +159,31 @@ describe Ministry, type: :model do
       end
     end
   end
+
+  context '.create_or_update_from_entity!' do
+    it 'updates an existing ministry based on the entity' do
+      ministry = create(:ministry)
+      entity = {
+        'ministry' => { 'id' => ministry.gr_id, 'name' => 'new name' }
+      }
+
+      Ministry.create_or_update_from_entity!(entity)
+
+      expect(ministry.reload.name).to eq 'new name'
+    end
+
+    it 'creates a new ministry if none exists for entity id' do
+      gr_id = SecureRandom.uuid
+      entity = {
+        'ministry' => { 'id' => gr_id, 'name' => 'name' }
+      }
+
+      expect do
+        Ministry.create_or_update_from_entity!(entity)
+      end.to change(Ministry, :count).by(1)
+
+      expect(Ministry.last.name).to eq 'name'
+      expect(Ministry.last.gr_id).to eq gr_id
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,4 +34,5 @@ RSpec.configure do |config|
   config.include CASHelpers
   config.include GlobalRegistryHelpers
   config.include ModelHelpers
+  config.include FactoryGirl::Syntax::Methods
 end

--- a/spec/workers/gr_sync/notification_worker_spec.rb
+++ b/spec/workers/gr_sync/notification_worker_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe GrSync::NotificationWorker, '#perform' do
+  describe 'sending change notifications to handler' do
+    it 'sends created' do
+      expect_change_notification_handled('created', :created_notification)
+    end
+    it 'sends updated' do
+      expect_change_notification_handled('updated', :updated_notification)
+    end
+    it 'sends deleted' do
+      expect_change_notification_handled('deleted', :deleted_notification)
+    end
+
+    def expect_change_notification_handled(action, expected_method)
+      notification = {
+        'entity_type' => 'person', 'id' => '1f', 'action' => action
+      }
+      handler = double(expected_method => nil)
+      allow(GrSync::ChangeNotificationHandler).to receive(:new) { handler }
+
+      GrSync::NotificationWorker.new.perform(notification)
+
+      expect(GrSync::ChangeNotificationHandler)
+        .to have_received(:new).with('person', '1f')
+      expect(handler).to have_received(expected_method)
+    end
+  end
+
+  describe 'sending merge notifications to handler' do
+    it 'sends merge success notifications to merge handler' do
+      notification = {
+        'action' => 'merge', 'new_id' => '1a', 'old_id' => '1b'
+      }
+      handler = double(merge_success_notification: nil)
+      allow(GrSync::MergeNotificationHandler).to receive(:new) { handler }
+
+      GrSync::NotificationWorker.new.perform(notification)
+
+      expect(GrSync::MergeNotificationHandler).to have_received(:new).with('1a', '1b')
+      expect(handler).to have_received(:merge_success_notification)
+    end
+
+    it 'sends merge conflict notifications to merge handler' do
+      notification = {
+        'action' => 'merge',
+        'winner' => { 'id' => '1a' }, 'loser' => { 'id' => '1b' }
+      }
+      handler = double(merge_conflict_notification: nil)
+      allow(GrSync::MergeNotificationHandler).to receive(:new) { handler }
+
+      GrSync::NotificationWorker.new.perform(notification)
+
+      expect(GrSync::MergeNotificationHandler).to have_received(:new).with('1a', '1b')
+      expect(handler).to have_received(:merge_conflict_notification)
+    end
+  end
+end

--- a/spec/workers/gr_sync/setup_subscriptions_worker_spec.rb
+++ b/spec/workers/gr_sync/setup_subscriptions_worker_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 describe GrSync::SetupSubscriptionsWorker, '#perform' do
   it 'subscribes the relevant entity types ids with correct endpoint' do
     endpoint = 'http://test.host/gr_sync/asdf/notifications'
-    allow(GrSync::EntityTypeFinder).to receive(:entity_type_ids)
-      .with(GrSync::SetupSubscriptionsWorker::ENTITY_NAMES) { %w(1f 2f) }
+    allow(GrSync::SubscribedEntities).to receive(:entity_type_ids) { %w(1f 2f) }
     manager = double(ensure_subscribed_to_all: nil)
     allow(GrSync::SubscriptionManager).to receive(:new) { manager }
 


### PR DESCRIPTION
This handles global registry notifications to ministry or person by updating or creating the corresponding record in our database.

I need to get some more context on the merge notifications so for now I've left those as just raising an error if they occur. If merges shouldn't happen for these entities then that's actually the right thing to do anyway (as if they ever did the error would alert us to it).