### PR TITLE
Always use root GR key for user updated assignments

### DIFF
--- a/app/controllers/v5/assignments_controller.rb
+++ b/app/controllers/v5/assignments_controller.rb
@@ -51,7 +51,13 @@ module V5
     end
 
     def load_assignment
-      @assignment ||= assignment_scope.find_by(gr_id: params[:id])
+      @assignment ||= find_and_decorate_assignment
+    end
+
+    def find_and_decorate_assignment
+      found_assignment = assignment_scope.find_by(gr_id: params[:id])
+      return nil unless found_assignment.present?
+      ::Assignment::UserUpdatedAssignment.new(found_assignment)
     end
 
     def build_assignment

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -22,8 +22,6 @@ class Assignment < ActiveRecord::Base
   validates :role, inclusion: { in: VALID_INPUT_ROLES, message: '\'%{value}\' is not a valid Team Role' }
   authorize_values_for :role
 
-  after_update :update_gr_relationship, if: 'gr_id.present?'
-
   scope :leaders, -> { where(leader_condition) }
   scope :local_leaders, -> { where(local_leader_condition) }
   scope :local_approved, -> { where(local_approved_condition) }
@@ -72,16 +70,6 @@ class Assignment < ActiveRecord::Base
     Assignment.new(person_id: person_id,
                    ministry_id: min_id.present? ? min_id : ministry_id,
                    role: inherited_role? ? role : "inherited_#{role}".to_sym)
-  end
-
-  protected
-
-  def update_gr_relationship
-    gr_client.put(gr_id, entity: { ministry_membership: { team_role: role } })
-  end
-
-  def gr_client
-    GlobalRegistryClient.client
   end
 
   class << self

--- a/app/models/assignment/user_updated_assignment.rb
+++ b/app/models/assignment/user_updated_assignment.rb
@@ -1,0 +1,21 @@
+# Allows you to decorate an Assignment instance to indicate that it has been
+# changed by a user and so should be synced to global registry.
+class Assignment
+  class UserUpdatedAssignment < SimpleDelegator
+    def save
+      save_succeeded = __getobj__.save
+      update_gr_relationship if save_succeeded
+      save_succeeded
+    end
+
+    private
+
+    def update_gr_relationship
+      root_gr_client.put(gr_id, entity: { ministry_membership: { team_role: role } })
+    end
+
+    def root_gr_client
+      GlobalRegistry::Entity.new
+    end
+  end
+end

--- a/spec/models/assignment/user_updated_assignment_spec.rb
+++ b/spec/models/assignment/user_updated_assignment_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Assignment::UserUpdatedAssignment do
+  context '#save' do
+    # The details of the sync request to global registry are covered in the
+    # integration specs for the assignments controller, so here just do a check
+    # that it only does the sync for a successful save.
+
+    it 'does not sync to global registry if the save did not succeed' do
+      assignment = double(save: false)
+      gr_client = double(put: nil)
+      allow(GlobalRegistry::Entity).to receive(:new) { gr_client }
+
+      Assignment::UserUpdatedAssignment.new(assignment).save
+
+      expect(gr_client).to_not have_received(:put)
+    end
+
+    it 'syncs to global registry if the save succeeded' do
+      assignment = double(save: true, gr_id: '1', role: 'r')
+      gr_client = double(put: nil)
+      allow(GlobalRegistry::Entity).to receive(:new) { gr_client }
+
+      Assignment::UserUpdatedAssignment.new(assignment).save
+
+      expect(gr_client).to have_received(:put)
+    end
+  end
+end

--- a/spec/support/global_registry_helpers.rb
+++ b/spec/support/global_registry_helpers.rb
@@ -63,6 +63,7 @@ module GlobalRegistryHelpers
   def gr_update_assignment_request(assignment)
     WebMock
       .stub_request(:put, "#{ENV['GLOBAL_REGISTRY_URL']}/entities/#{assignment.gr_id}")
+      .with(headers: { 'Authorization' => "Bearer #{ENV['GLOBAL_REGISTRY_TOKEN']}" })
       .to_return(status: 200, body: { entity: {} }.to_json, headers: {})
   end
 end


### PR DESCRIPTION
@Omicron7 this makes it so that the assignments that are updated are also always stored with the root global registry key (as per our conversation about doing that for security purposes).