### PR TITLE
Push ministry updates asyncronously to GR

### DIFF
--- a/app/controllers/v5/ministries_controller.rb
+++ b/app/controllers/v5/ministries_controller.rb
@@ -2,7 +2,8 @@
 module V5
   class MinistriesController < V5::BaseUserController
     power :ministries, map: {
-      [:show, :update] => :show_ministry,
+      [:show] => :show_ministry,
+      [:update] => :update_ministry,
       [:create] => :create_ministry
     }, as: :ministry_scope
 

--- a/app/controllers/v5/systems_ministries_controller.rb
+++ b/app/controllers/v5/systems_ministries_controller.rb
@@ -7,11 +7,19 @@ module V5
 
     def ministry_scope
       case params[:action].to_sym
-      when :show, :update
-        Ministry.find_by(gr_id: params[:id])
+      when :show
+        ministry
+      when :update
+        # For our purposes a system is a "user" in the sense that we will sync
+        # changes it makes to a ministry back to global registry.
+        Ministry::UserUpdatedMinistry.new(ministry) if ministry
       else
         Ministry.all
       end
+    end
+
+    def ministry
+      @ministry ||= Ministry.find_by(gr_id: params[:id])
     end
   end
 end

--- a/app/models/assignment/user_updated_assignment.rb
+++ b/app/models/assignment/user_updated_assignment.rb
@@ -4,7 +4,7 @@
 class Assignment
   class UserUpdatedAssignment < SimpleDelegator
     def save
-      save_succeeded = __getobj__.save
+      save_succeeded = super
       update_gr_relationship if save_succeeded
       save_succeeded
     end

--- a/app/models/concerns/gr_sync/entity_methods.rb
+++ b/app/models/concerns/gr_sync/entity_methods.rb
@@ -17,8 +17,10 @@ module GrSync
       from_entity self.class.find_entity(attribute_to_entity_property(:id), params)
     end
 
-    def update_entity(_params = {})
-      # TODO: implement
+    def async_update_entity
+      # Use the root global registry key by default which is what we do for
+      # updates to ministries, people and assignments.
+      GrSync::EntityUpdatePush.queue_with_root_gr(self)
     end
 
     def attribute_to_entity_property(property)

--- a/app/models/concerns/powers/ministry_powers.rb
+++ b/app/models/concerns/powers/ministry_powers.rb
@@ -14,6 +14,12 @@ module Powers
         ministry if inherited_assignment.present?
       end
 
+      power :update_ministry do
+        # Only leaders/inherited leaders may show or update a ministry
+        next unless ministry.present? && inherited_assignment.present?
+        ::Ministry::UserUpdatedMinistry.new(ministry)
+      end
+
       power :create_ministry do
         # current Assignment is for parent ministry
         # Anyone can create Ministries, only leaders of a ministry can create sub-ministries

--- a/app/models/gr_sync/entity_update_push.rb
+++ b/app/models/gr_sync/entity_update_push.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrSync
   class EntityUpdatePush
     def self.queue_with_root_gr(record)

--- a/app/models/gr_sync/entity_update_push.rb
+++ b/app/models/gr_sync/entity_update_push.rb
@@ -1,0 +1,17 @@
+module GrSync
+  class EntityUpdatePush
+    def self.queue_with_root_gr(record)
+      WithGrWorker.queue_call_with_root(self, :update_in_gr,
+                                        record.class.name, record.id)
+    end
+
+    def initialize(gr_client)
+      @gr_client = gr_client
+    end
+
+    def update_in_gr(model_name, id)
+      record = model_name.constantize.find(id)
+      @gr_client.entity.put(record.gr_id, record.to_entity)
+    end
+  end
+end

--- a/app/models/ministry/user_updated_ministry.rb
+++ b/app/models/ministry/user_updated_ministry.rb
@@ -1,0 +1,9 @@
+class Ministry
+  class UserUpdatedMinistry < SimpleDelegator
+    def save
+      success = super
+      async_update_entity if success
+      success
+    end
+  end
+end

--- a/app/models/ministry/user_updated_ministry.rb
+++ b/app/models/ministry/user_updated_ministry.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Ministry
   class UserUpdatedMinistry < SimpleDelegator
     def save

--- a/spec/models/gr_sync/entity_update_push_spec.rb
+++ b/spec/models/gr_sync/entity_update_push_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe GrSync::EntityUpdatePush do
+  context '.queue_call_with_root' do
+    it 'queues a WithGrWorker for the specified record' do
+      record = build_stubbed(:ministry, id: 1)
+      allow(GrSync::WithGrWorker).to receive(:queue_call_with_root)
+
+      GrSync::EntityUpdatePush.queue_with_root_gr(record)
+
+      expect(GrSync::WithGrWorker).to have_received(:queue_call_with_root)
+        .with(GrSync::EntityUpdatePush, :update_in_gr, 'Ministry', 1)
+    end
+
+    it 'works correctly to call update_in_gr when run' do
+      record = build_stubbed(:ministry, id: 1)
+      entity_update_push = instance_double(GrSync::EntityUpdatePush,
+                                           update_in_gr: nil)
+      allow(GrSync::EntityUpdatePush).to receive(:new) { entity_update_push }
+      gr_client = double
+      allow(GlobalRegistryClient).to receive(:new).with({}) { gr_client }
+      clear_uniqueness_locks
+
+      Sidekiq::Testing.inline! do
+        GrSync::EntityUpdatePush.queue_with_root_gr(record)
+      end
+
+      expect(GrSync::EntityUpdatePush).to have_received(:new).with(gr_client)
+      expect(entity_update_push).to have_received(:update_in_gr).with('Ministry', 1)
+    end
+  end
+
+  context 'update_in_gr' do
+    it 'pushing the entity for the specified model record' do
+      entity = { entity: { ministry: { name: 'name' } } }
+      ministry = build_stubbed(:ministry)
+      allow(ministry).to receive(:to_entity).and_return(entity)
+      allow(Ministry).to receive(:find).with(ministry.id) { ministry }
+      url = "#{ENV['GLOBAL_REGISTRY_URL']}/entities/#{ministry.gr_id}"
+      request_stub = stub_request(:put, url).with(body: entity.to_json)
+      gr_client = GlobalRegistryClient.new
+
+      GrSync::EntityUpdatePush.new(gr_client).update_in_gr('Ministry', ministry.id)
+
+      expect(request_stub).to have_been_requested
+    end
+  end
+end

--- a/spec/models/gr_sync/entity_update_push_spec.rb
+++ b/spec/models/gr_sync/entity_update_push_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe GrSync::EntityUpdatePush do

--- a/spec/models/ministry_spec.rb
+++ b/spec/models/ministry_spec.rb
@@ -246,4 +246,8 @@ describe Ministry, type: :model do
       expect(Ministry.last.gr_id).to eq gr_id
     end
   end
+
+  context '.update_entity' do
+
+  end
 end

--- a/spec/models/ministry_spec.rb
+++ b/spec/models/ministry_spec.rb
@@ -246,8 +246,4 @@ describe Ministry, type: :model do
       expect(Ministry.last.gr_id).to eq gr_id
     end
   end
-
-  context '.update_entity' do
-
-  end
 end

--- a/spec/requests/v5/ministries_spec.rb
+++ b/spec/requests/v5/ministries_spec.rb
@@ -242,8 +242,12 @@ RSpec.describe 'V5::Ministries', type: :request do
         end
 
         it 'responds successfully with updated ministry' do
+          allow(GrSync::EntityUpdatePush).to receive(:queue_with_root_gr)
+
           put "/v5/ministries/#{ministry.gr_id}", changes, 'HTTP_AUTHORIZATION': "Bearer #{authenticate_person person}"
 
+          expect(GrSync::EntityUpdatePush).to have_received(:queue_with_root_gr)
+            .with(ministry)
           expect(response).to be_success
           expect(response).to have_http_status(200)
           expect(response.body).to include_json(ministry.attributes.slice(%w(name location_zoom)).merge(changes))

--- a/spec/requests/v5/systems_ministries_spec.rb
+++ b/spec/requests/v5/systems_ministries_spec.rb
@@ -87,10 +87,14 @@ RSpec.describe 'V5::SystemsMinistries', type: :request do
     let(:ministry) { FactoryGirl.create(:ministry) }
     context 'valid ministry id' do
       it 'responds with the updated ministry details' do
+        allow(GrSync::EntityUpdatePush).to receive(:queue_with_root_gr)
+
         put "/v5/sys_ministries/#{ministry.gr_id}",
             { name: 'New Name', mccs: ['gcm'], ministry_scope: 'Area' },
             'HTTP_AUTHORIZATION': "Bearer #{gr_access_toke}"
 
+        expect(GrSync::EntityUpdatePush).to have_received(:queue_with_root_gr)
+          .with(ministry)
         expect(response).to be_success
         expect(response).to have_http_status(200)
         expect(json).to include_json(ministry_id: ministry.gr_id, name: 'New Name', ministry_scope: 'Area')


### PR DESCRIPTION
This pushes ministry updates done by users (or systems) to global registry using the root GR keys.