### PR TITLE
Add Sidekiq and Rack middlewares to reset GR client

### DIFF
--- a/app/middleware/rack_reset_gr_client.rb
+++ b/app/middleware/rack_reset_gr_client.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class RackResetGrClient
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    # The GlobalRegistryClient uses a thread store so reset it before every HTTP
+    # call so that it's always in a consistent starting state even if a call
+    # errors and a thread gets reused.
+    GlobalRegistryClient.parameters = nil
+    @app.call(env)
+  end
+end

--- a/app/middleware/sidekiq_reset_gr_client.rb
+++ b/app/middleware/sidekiq_reset_gr_client.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class SidekiqResetGrClient
+  def call(_worker, _job, _queue)
+    # The GlobalRegistryClient uses a thread store so reset it before every
+    # Sidekiq worker call that it's always in a consistent starting state even
+    # if a worker errors and a thread gets reused by another worker.
+    GlobalRegistryClient.parameters = nil
+    yield
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,8 @@ module MeasurementsApi
       end
     end
 
+    config.middleware.use 'RackResetGrClient'
+
     config.log_formatter = ::Logger::Formatter.new
 
     # RubyCAS config

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -17,6 +17,10 @@ Sidekiq.configure_server do |config|
   config.reliable_fetch!
   config.reliable_scheduler!
   config.redis = { url: Redis.current.client.id, namespace: sidekiq_namespace }
+
+  config.server_middleware do |chain|
+    chain.add SidekiqResetGrClient
+  end
 end
 
 Sidekiq.default_worker_options = {

--- a/spec/middleware/rack_reset_gr_client_spec.rb
+++ b/spec/middleware/rack_reset_gr_client_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe RackResetGrClient do
+  it 'sets GlobalRegistryClient parameters to empty and calls next in chain' do
+    app = double(call: nil)
+    env = double
+    GlobalRegistryClient.parameters = { access_token: 'a' }
+
+    RackResetGrClient.new(app).call(env)
+
+    expect(GlobalRegistryClient.parameters).to eq({})
+    expect(app).to have_received(:call).with(env)
+  end
+end

--- a/spec/middleware/sidekiq_reset_gr_client_spec.rb
+++ b/spec/middleware/sidekiq_reset_gr_client_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe SidekiqResetGrClient do
+  it 'sets GlobalRegistryClient parameters to empty and yields control' do
+    GlobalRegistryClient.parameters = { access_token: 'a' }
+
+    expect do |b|
+      SidekiqResetGrClient.new.call(double('worker'), double('job'), double('q'), &b)
+    end.to yield_control
+
+    expect(GlobalRegistryClient.parameters).to eq({})
+  end
+end


### PR DESCRIPTION
Because we're storing `GlobalRegistryClient.parameters` in a thread variable, I think it would be wise for us to reset it on every request / Sidekiq job just in case an exception occurs in a request/job and a thread gets reused by the server.

Potentially what we could do is eventually just always directly pass the global registry client to the places that need it (and add a `root_or_sys_gr_client` method potentially to a base level controller where we could get it from). But for now I think this is a useful safeguard.