### PR TITLE
Sync admin created people to global registry

### DIFF
--- a/app/controllers/v5/assignments_controller.rb
+++ b/app/controllers/v5/assignments_controller.rb
@@ -17,7 +17,8 @@ module V5
     end
 
     def create
-      permit_params %i(username key_guid person_id ministry_id team_role)
+      permit_params %i(username key_guid person_id ministry_id team_role
+                       first_name last_name email preferred_name ea_guid)
       if build_assignment
         render_assignment :created
       else

--- a/app/models/assignment/user_created_assignment.rb
+++ b/app/models/assignment/user_created_assignment.rb
@@ -19,7 +19,7 @@ class Assignment
 
     authorize_values_for :role
 
-    protected
+    private
 
     def lookup_ministry
       return if ministry_gr_id.blank?
@@ -30,11 +30,11 @@ class Assignment
       if person_gr_id.present?
         self.person = Person.for_gr_id(person_gr_id)
       elsif !username.blank?
-        self.person = Person.person_for_username(username)
+        self.person = find_or_create_person_by_username(username)
       elsif !key_guid.blank?
         # Legacy GMA identities saved user login as guid
         self.person = if key_guid.include?('@')
-                        Person.person_for_username(key_guid)
+                        find_or_create_person_by_username(key_guid)
                       else
                         Person.person(key_guid)
                       end
@@ -42,9 +42,12 @@ class Assignment
       create_person if person.blank?
     end
 
-    def create_person
-      # TODO: create person here if username, ea_guid or key_guid == email address set and person doesn't exist
-      self.person = Person.new
+    def find_or_create_person_by_username(username)
+      Person.person_for_username(username) || create_person_from_username(username)
+    end
+
+    def create_person_from_username(username)
+      Person.create!(cas_username: username)
     end
   end
 end

--- a/app/models/assignment/user_created_assignment.rb
+++ b/app/models/assignment/user_created_assignment.rb
@@ -8,6 +8,7 @@ class Assignment
                   :ministry_gr_id,
                   :first_name,
                   :last_name,
+                  :email,
                   :preferred_name,
                   :ea_guid
 
@@ -27,10 +28,12 @@ class Assignment
 
     def assign_person
       self.person = Person.person_for_gr_id(person_gr_id) ||
-                    person_by_username || person_for_key_guid
+                    person_for_key_guid || Person.person_for_ea_guid(ea_guid) ||
+                    person_by_username
     end
 
     def person_for_key_guid
+      return if key_guid.blank?
       # Legacy GMA identities saved user login as guid
       if key_guid.include?('@')
         person_by_username(key_guid)

--- a/app/models/assignment/user_created_assignment.rb
+++ b/app/models/assignment/user_created_assignment.rb
@@ -49,7 +49,8 @@ class Assignment
 
     def create_person_from_params
       person = Person.new(
-        cas_username: username, first_name: first_name, last_name: last_name)
+        cas_username: username, first_name: first_name, last_name: last_name,
+        email: email, preferred_name: preferred_name)
       person.create_entity
       person.save!
       person

--- a/app/models/assignment/user_created_assignment.rb
+++ b/app/models/assignment/user_created_assignment.rb
@@ -20,7 +20,7 @@ class Assignment
 
     def lookup_person
       if person_gr_id.present?
-        self.person = Person.find_by(gr_id: person_gr_id)
+        self.person = Person.for_gr_id(person_gr_id)
       elsif !username.blank?
         self.person = Person.person_for_username(username)
       elsif !key_guid.blank?

--- a/app/models/assignment/user_created_assignment.rb
+++ b/app/models/assignment/user_created_assignment.rb
@@ -2,7 +2,15 @@
 class Assignment
   class UserCreatedAssignment < ::Assignment
     # Virtual attributes
-    attr_accessor :username, :key_guid, :person_gr_id, :ministry_gr_id
+    attr_accessor :username,
+                  :key_guid,
+                  :person_gr_id,
+                  :ministry_gr_id,
+                  :first_name,
+                  :last_name,
+                  :email,
+                  :preferred_name,
+                  :ea_guid
 
     before_validation :lookup_person, on: :create
     before_validation :lookup_ministry, on: :create
@@ -31,6 +39,12 @@ class Assignment
                         Person.person(key_guid)
                       end
       end
+      create_person if person.blank?
+    end
+
+    def create_person
+      # TODO: create person here if username, ea_guid or key_guid == email address set and person doesn't exist
+      self.person = Person.new
     end
   end
 end

--- a/app/models/concerns/gr_sync/entity_methods.rb
+++ b/app/models/concerns/gr_sync/entity_methods.rb
@@ -6,7 +6,8 @@ module GrSync
     # Creates the entity in Global Registry
     def create_entity(_options = {})
       # TODO: Handle exceptions
-      self.class.client.post(to_entity)['entity'][self.class.entity_type].with_indifferent_access
+      entity = self.class.client.post(to_entity)['entity'][self.class.entity_type].with_indifferent_access
+      self.gr_id = entity[:id]
     end
 
     # Updates self from Global Registry entity with given :id

--- a/app/models/concerns/gr_sync/ministry.rb
+++ b/app/models/concerns/gr_sync/ministry.rb
@@ -36,13 +36,6 @@ module GrSync
       super lmi
     end
 
-    # Filter to create Global Registry Entity before creating ActiveRecord entry
-    def create_entity
-      entity = super
-      # update ministry_id from GR entity id
-      self.gr_id = entity[:id]
-    end
-
     # Model attribute value to Global Registry Entity property value
     # Return nil to remove property from the request
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -2,7 +2,7 @@
 class Person < ActiveRecord::Base
   include GrSync::EntityMethods
 
-  GR_FIELDS ='first_name,last_name,key_username,authentication.key_guid,'\
+  GR_FIELDS = 'first_name,last_name,key_username,authentication.key_guid,'\
     'authentication.ea_guid'
 
   has_many :user_content_locales, dependent: :destroy
@@ -106,6 +106,7 @@ class Person < ActiveRecord::Base
     end
 
     def person_for_gr_id(gr_id)
+      return if gr_id.blank?
       person = Person.find_by(gr_id: gr_id)
       return person if person
       entity = Person.find_entity(gr_id, entity_type: 'person')

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -51,61 +51,6 @@ class Person < ActiveRecord::Base
     inherited_assignment_for_ministry(ministry).try(:role)
   end
 
-  def self.entity_type
-    'person'
-  end
-
-  # Global Registry Entity Properties to sync
-  def self.entity_properties
-    [:first_name, :last_name, :key_username, :authentication].concat(super)
-  end
-
-  def self.person(guid, refresh = false)
-    person = find_by(cas_guid: guid)
-    if person.nil? || refresh
-      person = new(cas_guid: guid) if person.nil?
-      entity = find_entity_by_key_guid guid
-      return if entity.nil?
-      person.from_entity entity
-      person.save
-    end
-    person
-  end
-
-  def self.person_for_username(username, refresh = false)
-    person = find_by(cas_username: username)
-    if person.nil? || refresh
-      person = new if person.nil?
-      entity = find_entity_by(
-        entity_type: entity_type,
-        fields: 'first_name,last_name,key_username,authentication.key_guid',
-        'filters[key_username]': username
-      )
-      return if entity.nil?
-      person.from_entity entity
-      person.save
-    end
-    person
-  end
-
-  def self.person_for_gr_id(gr_id)
-    person = Person.find_by(gr_id: gr_id)
-    return person if person
-    entity = Person.find_entity(gr_id, entity_type: 'person')
-    person = Person.new
-    person.from_entity(entity)
-    person.save
-    person
-  end
-
-  def self.find_entity_by_key_guid(guid)
-    find_entity_by(
-      entity_type: entity_type,
-      fields: 'first_name,last_name,key_username,authentication.key_guid',
-      'filters[authentication][key_guid]': guid
-    )
-  end
-
   def full_name
     "#{first_name} #{last_name}"
   end
@@ -120,6 +65,75 @@ class Person < ActiveRecord::Base
       Ministry.ministry(ministry)
     elsif ministry.is_a? Ministry
       ministry
+    end
+  end
+
+  class << self
+    def entity_type
+      'person'
+    end
+
+    # Global Registry Entity Properties to sync
+    def entity_properties
+      [:first_name, :last_name, :key_username, :authentication].concat(super)
+    end
+
+    def person(cas_guid, refresh = false)
+      person_for_auth_guid(:cas, :key, cas_guid, refresh)
+    end
+
+    def person_for_ea_guid(ea_guid, refresh = false)
+      person_for_auth_guid(:ea, :ea, ea_guid, refresh)
+    end
+
+    def person_for_username(username, refresh = false)
+      person = find_by(cas_username: username)
+      if person.nil? || refresh
+        person = new if person.nil?
+        entity = find_entity_by(
+          entity_type: entity_type,
+          fields: 'first_name,last_name,key_username,authentication.key_guid',
+          'filters[key_username]': username
+        )
+        return if entity.nil?
+        person.from_entity entity
+        person.save
+      end
+      person
+    end
+
+    def person_for_gr_id(gr_id)
+      person = Person.find_by(gr_id: gr_id)
+      return person if person
+      entity = Person.find_entity(gr_id, entity_type: 'person')
+      person = Person.new
+      person.from_entity(entity)
+      person.save
+      person
+    end
+
+    private
+
+    def person_for_auth_guid(guid_field_prefix, gr_auth_prefix, guid, refresh)
+      guid_field = "#{guid_field_prefix}_guid"
+      person = find_by(guid_field => guid)
+      return person unless person.nil? || refresh
+
+      person = new(guid_field => guid) if person.nil?
+      entity = find_entity_by_auth_guid(gr_auth_prefix, guid)
+      return if entity.nil?
+      person.from_entity entity
+      person.save
+      person
+    end
+
+    def find_entity_by_auth_guid(gr_auth_prefix, guid)
+      find_entity_by(
+        entity_type: entity_type,
+        fields: 'first_name,last_name,key_username,authentication.key_guid,'\
+        'authentication.ea_guid',
+        "filters[authentication][#{gr_auth_prefix}_guid]": guid
+      )
     end
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -119,6 +119,7 @@ class Person < ActiveRecord::Base
     private
 
     def person_for_auth_guid(guid_field_prefix, gr_auth_prefix, guid, refresh)
+      return if guid.blank?
       guid_field = "#{guid_field_prefix}_guid"
       person = find_by(guid_field => guid)
       return person unless person.nil? || refresh

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -2,6 +2,9 @@
 class Person < ActiveRecord::Base
   include GrSync::EntityMethods
 
+  GR_FIELDS ='first_name,last_name,key_username,authentication.key_guid,'\
+    'authentication.ea_guid'
+
   has_many :user_content_locales, dependent: :destroy
   has_many :user_map_views, dependent: :destroy
   has_many :user_measurement_states, dependent: :destroy
@@ -92,7 +95,7 @@ class Person < ActiveRecord::Base
         person = new if person.nil?
         entity = find_entity_by(
           entity_type: entity_type,
-          fields: 'first_name,last_name,key_username,authentication.key_guid',
+          fields: GR_FIELDS,
           'filters[key_username]': username
         )
         return if entity.nil?
@@ -130,8 +133,7 @@ class Person < ActiveRecord::Base
     def find_entity_by_auth_guid(gr_auth_prefix, guid)
       find_entity_by(
         entity_type: entity_type,
-        fields: 'first_name,last_name,key_username,authentication.key_guid,'\
-        'authentication.ea_guid',
+        fields: GR_FIELDS,
         "filters[authentication][#{gr_auth_prefix}_guid]": guid
       )
     end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -78,7 +78,8 @@ class Person < ActiveRecord::Base
 
     # Global Registry Entity Properties to sync
     def entity_properties
-      [:first_name, :last_name, :key_username, :authentication].concat(super)
+      [:first_name, :last_name, :key_username, :authentication,
+       :email, :preferred_name].concat(super)
     end
 
     def person(cas_guid, refresh = false)

--- a/db/migrate/20160323195009_add_ea_guid_to_people.rb
+++ b/db/migrate/20160323195009_add_ea_guid_to_people.rb
@@ -1,5 +1,0 @@
-class AddEaGuidToPeople < ActiveRecord::Migration
-  def change
-    add_column :people, :ea_guid, :uuid
-  end
-end

--- a/db/migrate/20160323195009_add_ea_guid_to_people.rb
+++ b/db/migrate/20160323195009_add_ea_guid_to_people.rb
@@ -1,0 +1,5 @@
+class AddEaGuidToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :ea_guid, :uuid
+  end
+end

--- a/db/migrate/20160325143822_add_fields_to_people.rb
+++ b/db/migrate/20160325143822_add_fields_to_people.rb
@@ -1,0 +1,7 @@
+class AddFieldsToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :ea_guid, :uuid
+    add_column :people, :email, :string
+    add_column :people, :preferred_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160321203255) do
+ActiveRecord::Schema.define(version: 20160323195009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,6 +150,7 @@ ActiveRecord::Schema.define(version: 20160321203255) do
     t.string   "cas_username"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
+    t.uuid     "ea_guid"
   end
 
   create_table "stories", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160323195009) do
+ActiveRecord::Schema.define(version: 20160321203255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,7 +150,6 @@ ActiveRecord::Schema.define(version: 20160323195009) do
     t.string   "cas_username"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
-    t.uuid     "ea_guid"
   end
 
   create_table "stories", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160321203255) do
+ActiveRecord::Schema.define(version: 20160325143822) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -148,8 +148,11 @@ ActiveRecord::Schema.define(version: 20160321203255) do
     t.string   "last_name"
     t.uuid     "cas_guid"
     t.string   "cas_username"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.uuid     "ea_guid"
+    t.string   "email"
+    t.string   "preferred_name"
   end
 
   create_table "stories", force: :cascade do |t|

--- a/spec/models/assignment/user_created_assignment_spec.rb
+++ b/spec/models/assignment/user_created_assignment_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Assignment::UserCreatedAssignment do
+  it 'looks up person by ea_guid if specified' do
+    ea_guid = SecureRandom.uuid
+    ministry = create(:ministry)
+    person = build(:person, ea_guid: ea_guid)
+    allow(Person).to receive(:person_for_ea_guid) { person }
+    stub_request(:put, %r{#{ENV['GLOBAL_REGISTRY_URL']}/.*}).to_return(body: {
+      entity: { person: { 'ministry:relationship': [{
+        ministry: ministry.gr_id,
+        relationship_entity_id: SecureRandom.uuid
+      }] } }
+    }.to_json)
+    assignment = Assignment::UserCreatedAssignment.new(ministry: ministry,
+                                                       ea_guid: ea_guid)
+
+    expect(assignment.save).to be true
+    expect(assignment.person).to eq person
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -34,7 +34,7 @@ describe Person, type: :model do
     it 'fetches a person from global registry if one does not exist' do
       cas_guid = SecureRandom.uuid
       url = "#{ENV['GLOBAL_REGISTRY_URL']}/entities?entity_type=person&"\
-        "fields=first_name,last_name,key_username,authentication.key_guid,"\
+        'fields=first_name,last_name,key_username,authentication.key_guid,'\
         "authentication.ea_guid&filters%5Bauthentication%5D%5Bkey_guid%5D=#{cas_guid}"
       response = {
         entities: [
@@ -61,7 +61,7 @@ describe Person, type: :model do
     it 'fetches a person from global registry if one does not exist' do
       ea_guid = SecureRandom.uuid
       url = "#{ENV['GLOBAL_REGISTRY_URL']}/entities?entity_type=person&"\
-        "fields=first_name,last_name,key_username,authentication.key_guid,"\
+        'fields=first_name,last_name,key_username,authentication.key_guid,'\
         "authentication.ea_guid&filters%5Bauthentication%5D%5Bea_guid%5D=#{ea_guid}"
       response = {
         entities: [

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -25,6 +25,59 @@ describe Person, type: :model do
     end
   end
 
+  context '.person' do
+    it 'returns an existing person by cas guid' do
+      person = create(:person, cas_guid: SecureRandom.uuid)
+      expect(Person.person(person.cas_guid)).to eq person
+    end
+
+    it 'fetches a person from global registry if one does not exist' do
+      cas_guid = SecureRandom.uuid
+      url = "#{ENV['GLOBAL_REGISTRY_URL']}/entities?entity_type=person&"\
+        "fields=first_name,last_name,key_username,authentication.key_guid,"\
+        "authentication.ea_guid&filters%5Bauthentication%5D%5Bkey_guid%5D=#{cas_guid}"
+      response = {
+        entities: [
+          { person: { first_name: 'Joe' } }
+        ]
+      }
+      request_stub = stub_request(:get, url).to_return(body: response.to_json)
+
+      person = Person.person(cas_guid)
+
+      expect(person).to_not be_new_record
+      expect(person.first_name).to eq 'Joe'
+      expect(person.cas_guid).to eq cas_guid
+      expect(request_stub).to have_been_requested
+    end
+  end
+
+  context '.person_for_ea_guid' do
+    it 'returns an existing person by ea_guid' do
+      person = create(:person, ea_guid: SecureRandom.uuid)
+      expect(Person.person_for_ea_guid(person.ea_guid)).to eq person
+    end
+
+    it 'fetches a person from global registry if one does not exist' do
+      ea_guid = SecureRandom.uuid
+      url = "#{ENV['GLOBAL_REGISTRY_URL']}/entities?entity_type=person&"\
+        "fields=first_name,last_name,key_username,authentication.key_guid,"\
+        "authentication.ea_guid&filters%5Bauthentication%5D%5Bea_guid%5D=#{ea_guid}"
+      response = {
+        entities: [
+          { person: { first_name: 'Joe' } }
+        ]
+      }
+      stub_request(:get, url).to_return(body: response.to_json)
+
+      person = Person.person_for_ea_guid(ea_guid)
+
+      expect(person).to_not be_new_record
+      expect(person.first_name).to eq 'Joe'
+      expect(person.ea_guid).to eq ea_guid
+    end
+  end
+
   context '.person_for_gr_id' do
     it 'finds a person for the gr_id if they exist already' do
       gr_id = SecureRandom.uuid

--- a/spec/requests/v5/assignments_spec.rb
+++ b/spec/requests/v5/assignments_spec.rb
@@ -283,9 +283,12 @@ RSpec.describe 'V5::Assignments', type: :request do
       end
 
       context 'create assignment for another user by username when they do not exist in GR' do
-        let(:other) { FactoryGirl.build(:person) }
+        let(:other) { FactoryGirl.build(:person, email: 'j@t.co', preferred_name: 'Jo') }
         let(:attributes) do
-          { username: other.cas_username, ministry_id: ministries[:a22].gr_id, team_role: 'member' }
+          { username: other.cas_username, ministry_id: ministries[:a22].gr_id,
+            team_role: 'member', first_name: other.first_name,
+            last_name: other.last_name, email: other.email,
+            preferred_name: other.preferred_name }
         end
         let(:new_assignment) do
           FactoryGirl.build(:assignment, person: other, ministry: ministries[:a22], role: 'member')
@@ -297,7 +300,9 @@ RSpec.describe 'V5::Assignments', type: :request do
         let!(:create_person_stub) { gr_create_person_request(other) }
 
         it 'responds successfully with new assignment' do
-          post '/v5/assignments', attributes, 'HTTP_AUTHORIZATION': "Bearer #{authenticate_person person}"
+          expect do
+            post '/v5/assignments', attributes, 'HTTP_AUTHORIZATION': "Bearer #{authenticate_person person}"
+          end.to change(Person, :count).by(1)
 
           expect(response).to be_success
           expect(response).to have_http_status 201

--- a/spec/support/global_registry_helpers.rb
+++ b/spec/support/global_registry_helpers.rb
@@ -11,14 +11,6 @@ module GlobalRegistryHelpers
       .to_return(body: { entities: [person_gr_response(person)] }.to_json)
   end
 
-  def gr_person_request_by_gr_id(person)
-    WebMock
-      .stub_request(:get, "#{ENV['GLOBAL_REGISTRY_URL']}/entities/#{person.gr_id}")
-      .with(headers: { 'Authorization' => "Bearer #{ENV['GLOBAL_REGISTRY_TOKEN']}" })
-      .with(query: { entity_type: 'person' })
-      .to_return(body: { entities: [person_gr_response(person)] }.to_json)
-  end
-
   def person_gr_response(person)
     { person: { id: person.gr_id, last_name: person.last_name, first_name: person.first_name,
                 key_username: person.cas_username, client_integration_id: person.cas_guid,

--- a/spec/support/global_registry_helpers.rb
+++ b/spec/support/global_registry_helpers.rb
@@ -39,7 +39,11 @@ module GlobalRegistryHelpers
     WebMock.stub_request(:post, "#{ENV['GLOBAL_REGISTRY_URL']}/entities").with(
       headers: { 'Authorization' => "Bearer #{ENV['GLOBAL_REGISTRY_TOKEN']}" },
       body: {
-        entity: { person: { key_username: person.cas_username } }
+        entity: { person: {
+          first_name: person.first_name, last_name: person.last_name,
+          key_username: person.cas_username, email: person.email,
+          preferred_name: person.preferred_name
+        } }
       }.to_json
     ).to_return(body: {
       entity: { person: { key_username: person.cas_username, id: person.gr_id } }

--- a/spec/support/global_registry_helpers.rb
+++ b/spec/support/global_registry_helpers.rb
@@ -2,16 +2,48 @@
 module GlobalRegistryHelpers
   def gr_person_request_by_username(person = nil)
     person ||= FactoryGirl.create(:person)
-    response = { person: { id: person.gr_id, last_name: person.last_name, first_name: person.first_name,
-                           key_username: person.cas_username, client_integration_id: person.cas_guid,
-                           authentication: { id: SecureRandom.uuid, key_guid: person.cas_guid } } }
     WebMock
       .stub_request(:get, "#{ENV['GLOBAL_REGISTRY_URL']}/entities")
       .with(headers: { 'Authorization' => "Bearer #{ENV['GLOBAL_REGISTRY_TOKEN']}" })
       .with(query: { entity_type: 'person',
-                     fields: 'first_name,last_name,key_username,authentication.key_guid',
+                     fields: Person::GR_FIELDS,
                      'filters[key_username]': person.cas_username })
-      .to_return(status: 200, body: { entities: [response] }.to_json, headers: {})
+      .to_return(body: { entities: [person_gr_response(person)] }.to_json)
+  end
+
+  def gr_person_request_by_gr_id(person)
+    WebMock
+      .stub_request(:get, "#{ENV['GLOBAL_REGISTRY_URL']}/entities/#{person.gr_id}")
+      .with(headers: { 'Authorization' => "Bearer #{ENV['GLOBAL_REGISTRY_TOKEN']}" })
+      .with(query: { entity_type: 'person' })
+      .to_return(body: { entities: [person_gr_response(person)] }.to_json)
+  end
+
+  def person_gr_response(person)
+    { person: { id: person.gr_id, last_name: person.last_name, first_name: person.first_name,
+                key_username: person.cas_username, client_integration_id: person.cas_guid,
+                authentication: { id: SecureRandom.uuid, key_guid: person.cas_guid } } }
+  end
+
+  def gr_person_request_by_username_not_found(username)
+    WebMock
+      .stub_request(:get, "#{ENV['GLOBAL_REGISTRY_URL']}/entities")
+      .with(headers: { 'Authorization' => "Bearer #{ENV['GLOBAL_REGISTRY_TOKEN']}" })
+      .with(query: { entity_type: 'person',
+                     fields: Person::GR_FIELDS,
+                     'filters[key_username]': username })
+      .to_return(body: { entities: [] }.to_json)
+  end
+
+  def gr_create_person_request(person)
+    WebMock.stub_request(:post, "#{ENV['GLOBAL_REGISTRY_URL']}/entities").with(
+      headers: { 'Authorization' => "Bearer #{ENV['GLOBAL_REGISTRY_TOKEN']}" },
+      body: {
+        entity: { person: { key_username: person.cas_username } }
+      }.to_json
+    ).to_return(body: {
+      entity: { person: { key_username: person.cas_username, id: person.gr_id } }
+    }.to_json)
   end
 
   def gr_person_request_by_guid(person = nil)
@@ -23,7 +55,7 @@ module GlobalRegistryHelpers
       .stub_request(:get, "#{ENV['GLOBAL_REGISTRY_URL']}/entities")
       .with(headers: { 'Authorization' => "Bearer #{ENV['GLOBAL_REGISTRY_TOKEN']}" })
       .with(query: { entity_type: 'person',
-                     fields: 'first_name,last_name,key_username,authentication.key_guid',
+                     fields: Person::GR_FIELDS,
                      'filters[authentication][key_guid]': person.cas_guid })
       .to_return(status: 200, body: { entities: [response] }.to_json, headers: {})
   end
@@ -46,22 +78,20 @@ module GlobalRegistryHelpers
   end
 
   def gr_create_assignment_request(assignment)
-    response = { person: {
-      id: assignment.person.gr_id,
-      'ministry:relationship' => [{ ministry: assignment.ministry.gr_id,
-                                    relationship_entity_id: assignment.gr_id || SecureRandom.uuid,
-                                    client_integration_id: "_#{assignment.person.gr_id}_#{assignment.ministry.gr_id}",
-                                    team_role: assignment.role
-                                  }] } }
-
     # We need to always create assignments using the root GLOBAL_REGISTRY_TOKEN
-    # keey and not a system key to prevent a system from gaining
-    # higher-than-planned access to the measurements api data.
     WebMock
       .stub_request(:put, "#{ENV['GLOBAL_REGISTRY_URL']}/entities/#{assignment.person.gr_id}")
       .with(query: { fields: 'ministry:relationship', full_response: 'true' },
             headers: { 'Authorization' => "Bearer #{ENV['GLOBAL_REGISTRY_TOKEN']}" })
-      .to_return(status: 200, body: { entity: response }.to_json, headers: {})
+      .to_return(
+        body: { entity: { person: {
+          id: assignment.person.gr_id,
+          'ministry:relationship' => [
+            { ministry: assignment.ministry.gr_id,
+              relationship_entity_id: assignment.gr_id || SecureRandom.uuid,
+              client_integration_id: "_#{assignment.person.gr_id}_#{assignment.ministry.gr_id}",
+              team_role: assignment.role }]
+        } } }.to_json)
   end
 
   def gr_update_assignment_request(assignment)


### PR DESCRIPTION
This makes it so that when someone creates an assignment they can specify the person by `ea_guid` or pass in parameters about the person like `first_name`, `last_name`  and `cas_username` and a new person will be created and synced to GR even if the person does not exist yet in GR.