### PR TITLE
Fix GR notifications controller for GR notification format

### DIFF
--- a/app/controllers/gr_sync/notifications_controller.rb
+++ b/app/controllers/gr_sync/notifications_controller.rb
@@ -5,9 +5,19 @@ module GrSync
       if params[:confirmation_url].present?
         ConfirmSubscriptionWorker.perform_async(params[:confirmation_url])
       else
-        NotificationWorker.perform_async(params)
+        NotificationWorker.perform_async(notification_params)
       end
       render nothing: true
+    end
+
+    private
+
+    def notification_params
+      # Don't use params because it will set action to 'create' because that's
+      # the controller action when what we really want is the action of the
+      # notification that global registry sent to us.
+      request.POST.slice(:action, :id, :client_integration_id, :triggered_by,
+                         :entity_type)
     end
   end
 end

--- a/app/controllers/gr_sync/notifications_controller.rb
+++ b/app/controllers/gr_sync/notifications_controller.rb
@@ -5,7 +5,7 @@ module GrSync
       if params[:confirmation_url].present?
         ConfirmSubscriptionWorker.perform_async(params[:confirmation_url])
       else
-        NotificationWorker.perform_async(params[:notification])
+        NotificationWorker.perform_async(params)
       end
       render nothing: true
     end

--- a/spec/controllers/gr_sync/notifications_controller_spec.rb
+++ b/spec/controllers/gr_sync/notifications_controller_spec.rb
@@ -15,7 +15,7 @@ describe GrSync::NotificationsController do
     it 'queues a notification worker if confirmation url not present' do
       allow(GrSync::NotificationWorker).to receive(:perform_async)
 
-      post :create, notification: { 'action' => 'updated', 'id' => '1f' }
+      post :create, { 'action' => 'updated', 'id' => '1f' }
 
       expect(GrSync::NotificationWorker).to have_received(:perform_async)
         .with('action' => 'updated', 'id' => '1f')

--- a/spec/controllers/gr_sync/notifications_controller_spec.rb
+++ b/spec/controllers/gr_sync/notifications_controller_spec.rb
@@ -15,7 +15,7 @@ describe GrSync::NotificationsController do
     it 'queues a notification worker if confirmation url not present' do
       allow(GrSync::NotificationWorker).to receive(:perform_async)
 
-      post :create, { 'action' => 'updated', 'id' => '1f' }
+      post :create, 'action' => 'updated', 'id' => '1f'
 
       expect(GrSync::NotificationWorker).to have_received(:perform_async)
         .with('action' => 'updated', 'id' => '1f')

--- a/spec/requests/gr_sync/notifications_spec.rb
+++ b/spec/requests/gr_sync/notifications_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe GrSync::NotificationsController do
+describe 'Global registry notifications', type: :request do
   context '#create' do
     it 'queues a subscription confirmation worker if confirmation url present' do
       allow(GrSync::ConfirmSubscriptionWorker).to receive(:perform_async)
 
-      post :create, confirmation_url: 'global-registry.org/confirm/abc'
+      post gr_sync_notifications_url, confirmation_url: 'global-registry.org/confirm/abc'
 
       expect(GrSync::ConfirmSubscriptionWorker).to have_received(:perform_async)
         .with('global-registry.org/confirm/abc')
@@ -15,7 +15,7 @@ describe GrSync::NotificationsController do
     it 'queues a notification worker if confirmation url not present' do
       allow(GrSync::NotificationWorker).to receive(:perform_async)
 
-      post :create, 'action' => 'updated', 'id' => '1f'
+      post gr_sync_notifications_url, action: 'updated', id: '1f'
 
       expect(GrSync::NotificationWorker).to have_received(:perform_async)
         .with('action' => 'updated', 'id' => '1f')


### PR DESCRIPTION
I had included the `params[:notification]` based on how [the summer missions app does it](https://github.com/CruGlobal/summer_missions/blob/master/app/controllers/gr/notifications_controller.rb).

But it seems like based on this error https://rollbar.com/Cru/measurements-api/items/22/ and the Global Registry [docs](https://github.com/CruGlobal/global_registry_docs/wiki/Subscriptions-API) and [source](https://github.com/CruGlobal/global_registry/blob/master/app/workers/subscription/publisher_worker.rb) that the notification messages don't have `notification` as a key, they just give the notification info directly.