### PR TITLE
Symbolize GR client param keys

### DIFF
--- a/app/workers/gr_sync/with_gr_worker.rb
+++ b/app/workers/gr_sync/with_gr_worker.rb
@@ -17,7 +17,7 @@ module GrSync
       # on classes in the GrSync namespace.
       raise "#{klass_name} not in GrSync::" unless klass_name.to_s.start_with?('GrSync::')
 
-      gr_client = GlobalRegistryClient.new(gr_client_params)
+      gr_client = GlobalRegistryClient.new(gr_client_params&.symbolize_keys)
       klass_name.constantize.new(gr_client).public_send(method, *args)
     end
   end

--- a/spec/workers/gr_sync/with_gr_worker_spec.rb
+++ b/spec/workers/gr_sync/with_gr_worker_spec.rb
@@ -28,7 +28,7 @@ describe GrSync::WithGrWorker do
         GrSync::WithGrWorker.drain
       end.to change(GrSync::WithGrWorker.jobs, :size).by(-1)
 
-      expect(GlobalRegistryClient).to have_received(:new).with(gr_params)
+      expect(GlobalRegistryClient).to have_received(:new).with(access_token: 'zzz')
       expect(gr_sync_test).to have_received(:test).with('arg')
     end
 


### PR DESCRIPTION
Sidekiq stringifys all Hash keys when serializing to redis. GlobalRegistry::Base expects symbols, so we need to convert them.