### PR TITLE
fix time-based spec ⏲💣

### DIFF
--- a/spec/requests/v5/trainings_spec.rb
+++ b/spec/requests/v5/trainings_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'V5::Trainings', type: :request do
   let(:user) { FactoryGirl.create(:person) }
 
   describe 'GET /v5/training' do
-    let!(:training) { FactoryGirl.create(:training, ministry: ministry) }
+    let!(:training) { FactoryGirl.create(:training, ministry: ministry, date: 1.month.ago) }
     let(:json) { JSON.parse(response.body) }
 
     it 'responds with trainings' do


### PR DESCRIPTION
Because the trainings controller loads the last year by default, and the factory sets the date to Feb 19, 2016, this was a time-bomb spec. 